### PR TITLE
require_once -> require due to APC issues

### DIFF
--- a/FeedWriter.php
+++ b/FeedWriter.php
@@ -29,7 +29,7 @@ define('RSS2', 'RSS 2.0', true);
 define('ATOM', 'ATOM', true);
 
 if (!class_exists('FeedItem'))
-	require './FeedItem.php';
+	require __DIR__.'/FeedItem.php';
 
 /**
  * Universal Feed Writer class


### PR DESCRIPTION
Using class_exists and require instead of require_once because of performance improvements in relationship to APC.

APC shouldn't have to open files more than once, but it does if you use require_once instead of require. More details here:
http://www.techyouruniverse.com/software/php-performance-tip-require-versus-require_once
