### PR TITLE
ATOM feed <author> element fix

### DIFF
--- a/FeedItem.php
+++ b/FeedItem.php
@@ -225,7 +225,7 @@ class FeedItem
 		if ($this->version != ATOM)
 			return;
 
-		$this->addElement('author', '<name>' . $author . '</name>');
+		$this->addElement('author', array('name' => $author));
 	}
 
 	/**


### PR DESCRIPTION
When generating an ATOM feed, the author element was being generated as

```
<author>&lt;name&gt;Paul Ferrett&lt;/name&gt;</author>
```

because the <name> tag was being html encoded by the writer.
