### PR TITLE
namespace FeedWriter

### DIFF
--- a/ATOM.php
+++ b/ATOM.php
@@ -1,0 +1,34 @@
+<?php
+namespace FeedWriter;
+
+/* 
+ * Copyright (C) 2012 Michael Bemmerl <mail@mx-server.de>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Wrapper for creating ATOM feeds
+ *
+ * @package     UniversalFeedWriter
+ */
+class Atom extends Feed
+{
+	function __construct()
+	{
+		parent::__construct(Feed::ATOM);
+	}
+}

--- a/Item.php
+++ b/Item.php
@@ -1,4 +1,7 @@
 <?php
+namespace FeedWriter;
+
+use \DateTime;
 
 /* 
  * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
@@ -15,21 +18,21 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
-* 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- /**
+/**
  * Universal Feed Writer
- * 
+ *
  * FeedItem class - Used as feed element in FeedWriter class
  *
  * @package         UniversalFeedWriter
  * @author          Anis uddin Ahmad <anisniit@gmail.com>
  * @link            http://www.ajaxray.com/projects/rss
  */
-class FeedItem
+class Item
 {
 	private $elements = array();    //Collection of feed elements
 	private $version;
@@ -37,16 +40,16 @@ class FeedItem
 	/**
 	* Constructor
 	* 
-	* @param    contant     (RSS1/RSS2/ATOM) RSS2 is default.
+	* @param    constant     (RSS1/RSS2/ATOM) RSS2 is default.
 	*/ 
-	function __construct($version = RSS2)
+	function __construct($version = Feed::RSS2)
 	{
 		$this->version = $version;
 	}
 	
 	/**
 	* Add an element to elements array
-	* 
+	*
 	* @access   public
 	* @param    string  The tag name of an element
 	* @param    string  The content of tag
@@ -68,7 +71,7 @@ class FeedItem
 	/**
 	* Set multiple feed elements from an array.
 	* Elements which have attributes cannot be added by this method
-	* 
+	*
 	* @access   public
 	* @param    array   array of elements in 'tagName' => 'tagContent' format.
 	* @return   void
@@ -86,7 +89,7 @@ class FeedItem
 	
 	/**
 	* Return the collection of elements in this feed item
-	* 
+	*
 	* @access   public
 	* @return   array
 	*/
@@ -109,7 +112,7 @@ class FeedItem
 	// Wrapper functions ------------------------------------------------------
 	
 	/**
-	* Set the 'dscription' element of feed item
+	* Set the 'description' element of feed item
 	* 
 	* @access   public
 	* @param    string  The content of 'description' or 'summary' element
@@ -117,7 +120,7 @@ class FeedItem
 	*/
 	public function setDescription($description)
 	{
-		$tag = ($this->version == ATOM) ? 'summary' : 'description';
+		$tag = ($this->version == Feed::ATOM) ? 'summary' : 'description';
 		$this->addElement($tag, $description);
 	}
 	
@@ -145,7 +148,7 @@ class FeedItem
 		{
 			if ($date instanceof DateTime)
 			{
-				if (version_compare(PHP_VERSION, '5.3.0', '>='))
+				if (version_compare(\PHP_VERSION, '5.3.0', '>='))
 					$date = $date->getTimestamp();
 				else
 					$date = strtotime($date->format('r'));
@@ -154,15 +157,15 @@ class FeedItem
 				$date = strtotime($date);
 		}
 		
-		if($this->version == ATOM)
+		if($this->version == Feed::ATOM)
 		{
 			$tag    = 'updated';
-			$value  = date(DATE_ATOM, $date);
+			$value  = date(\DATE_ATOM, $date);
 		}
-		elseif($this->version == RSS2)
+		elseif($this->version == Feed::RSS2)
 		{
 			$tag    = 'pubDate';
-			$value  = date(DATE_RSS, $date);
+			$value  = date(\DATE_RSS, $date);
 		}
 		else
 		{
@@ -182,14 +185,14 @@ class FeedItem
 	*/
 	public function setLink($link)
 	{
-		if($this->version == RSS2 || $this->version == RSS1)
+		if($this->version == Feed::RSS2 || $this->version == Feed::RSS1)
 		{
 			$this->addElement('link', $link);
 		}
 		else
 		{
 			$this->addElement('link','',array('href'=>$link));
-			$this->addElement('id', FeedWriter::uuid($link,'urn:uuid:'));
+			$this->addElement('id', Feed::uuid($link,'urn:uuid:'));
 		}
 	}
 	
@@ -205,7 +208,7 @@ class FeedItem
 	*/
 	public function setEncloser($url, $length, $type)
 	{
-		if ($this->version != RSS2)
+		if ($this->version != Feed::RSS2)
 			return;
 
 		$attributes = array('url'=>$url, 'length'=>$length, 'type'=>$type);
@@ -222,7 +225,7 @@ class FeedItem
 	*/
 	public function setAuthor($author)
 	{
-		if ($this->version != ATOM)
+		if ($this->version != Feed::ATOM)
 			return;
 
 		$this->addElement('author', array('name' => $author));
@@ -237,13 +240,13 @@ class FeedItem
 	*/
 	public function setId($id)
 	{
-		if ($this->version == RSS2)
+		if ($this->version == Feed::RSS2)
 		{
 			$this->addElement('guid', $id, array('isPermaLink' => 'false'));
 		}
-		else if ($this->version == ATOM)
+		else if ($this->version == Feed::ATOM)
 		{
-			$this->addElement('id', FeedWriter::uuid($id,'urn:uuid:'), NULL, TRUE);
+			$this->addElement('id', Feed::uuid($id,'urn:uuid:'), NULL, TRUE);
 		}
 	}
 	

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 This package can be used to generate feeds in either RSS 1.0, RSS 2.0 or ATOM
 formats.
 
-There are three main classes that abstracts the feed information and another to
+There are three main classes that abstract the feed information and another to
 encapsulate the feed items information.
 
 Applications can create feed writer object, several feed item objects, set
@@ -16,4 +16,4 @@ The feed is generated as part of the current feed output.
 Requirements
 ============
 
-PHP >= 5.0
+PHP >= 5.3

--- a/RSS1.php
+++ b/RSS1.php
@@ -1,4 +1,5 @@
 <?php
+namespace FeedWriter;
 
 /* 
  * Copyright (C) 2012 Michael Bemmerl <mail@mx-server.de>
@@ -19,44 +20,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-if (!class_exists('FeedWriter'))
-	require dirname(__FILE__) . '/FeedWriter.php';
-
 /**
  * Wrapper for creating RSS1 feeds
  *
  * @package     UniversalFeedWriter
  */
-class RSS1FeedWriter extends FeedWriter
+class RSS1 extends Feed
 {
 	function __construct()
 	{
-		parent::__construct(RSS1);
-	}
-}
-
-/**
- * Wrapper for creating RSS2 feeds
- *
- * @package     UniversalFeedWriter
- */
-class RSS2FeedWriter extends FeedWriter
-{
-	function __construct()
-	{
-		parent::__construct(RSS2);
-	}
-}
-
-/**
- * Wrapper for creating ATOM feeds
- *
- * @package     UniversalFeedWriter
- */
-class ATOMFeedWriter extends FeedWriter
-{
-	function __construct()
-	{
-		parent::__construct(ATOM);
+		parent::__construct(Feed::RSS1);
 	}
 }

--- a/RSS2.php
+++ b/RSS2.php
@@ -1,0 +1,34 @@
+<?php
+namespace FeedWriter;
+
+/* 
+ * Copyright (C) 2012 Michael Bemmerl <mail@mx-server.de>
+ *
+ * This file is part of the "Universal Feed Writer" project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Wrapper for creating RSS2 feeds
+ *
+ * @package     UniversalFeedWriter
+ */
+class RSS2 extends Feed
+{
+	function __construct()
+	{
+		parent::__construct(Feed::RSS2);
+	}
+}

--- a/examples/example_atom.php
+++ b/examples/example_atom.php
@@ -1,6 +1,7 @@
 <?php
+use \FeedWriter\ATOM;
 
-/* 
+/*
  * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
  *
  * This file is part of the "Universal Feed Writer" project.
@@ -14,46 +15,40 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
-* 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// IMPORTANT : No need to add id for feed or channel. It will be automatically created from link.
 
-	include("../FeedTypes.php");
-	
-	// IMPORTANT : No need to add id for feed or channel. It will be automatically created from link.
+//Creating an instance of ATOM class.
+$TestFeed = new ATOM;
 
-	//Creating an instance of ATOMFeedWriter class. 
-	//The constant ATOM is passed to mention the version
-	$TestFeed = new ATOMFeedWriter();
+//Setting the channel elements
+//Use wrapper functions for common elements
+$TestFeed->setTitle('Testing the RSS writer class');
+$TestFeed->setLink('http://www.ajaxray.com/rss2/channel/about');
 
-	//Setting the channel elements
-	//Use wrapper functions for common elements
-	$TestFeed->setTitle('Testing the RSS writer class');
-	$TestFeed->setLink('http://www.ajaxray.com/rss2/channel/about');
-	
-	//For other channel elements, use setChannelElement() function
-	$TestFeed->setChannelElement('updated', date(DATE_ATOM , time()));
-	$TestFeed->setChannelElement('author', array('name'=>'Anis uddin Ahmad'));
+//For other channel elements, use setChannelElement() function
+$TestFeed->setChannelElement('updated', date(\DATE_ATOM , time()));
+$TestFeed->setChannelElement('author', array('name'=>'Anis uddin Ahmad'));
 
-	//Adding a feed. Genarally this protion will be in a loop and add all feeds.
+//Adding a feed. Generally this portion will be in a loop and add all feeds.
 
-	//Create an empty FeedItem
-	$newItem = $TestFeed->createNewItem();
-	
-	//Add elements to the feed item
-	//Use wrapper functions to add common feed elements
-	$newItem->setTitle('The first feed');
-	$newItem->setLink('http://www.yahoo.com');
-	$newItem->setDate(time());
-	//Internally changed to "summary" tag for ATOM feed
-	$newItem->setDescription('This is a test of adding CDATA encoded description by the php <b>Universal Feed Writer</b> class');
+//Create an empty Item
+$newItem = $TestFeed->createNewItem();
 
-	//Now add the feed item	
-	$TestFeed->addItem($newItem);
-	
-	//OK. Everything is done. Now genarate the feed.
-	$TestFeed->generateFeed();
-  
-?>
+//Add elements to the feed item
+//Use wrapper functions to add common feed elements
+$newItem->setTitle('The first feed');
+$newItem->setLink('http://www.yahoo.com');
+$newItem->setDate(time());
+//Internally changed to "summary" tag for ATOM feed
+$newItem->setDescription('This is a test of adding CDATA encoded description by the php <b>Universal Feed Writer</b> class');
+
+//Now add the feed item	
+$TestFeed->addItem($newItem);
+
+//OK. Everything is done. Now generate the feed.
+$TestFeed->printFeed();

--- a/examples/example_minimum.php
+++ b/examples/example_minimum.php
@@ -1,4 +1,5 @@
 <?php
+use \FeedWriter\RSS2;
 
 /* 
  * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
@@ -19,40 +20,36 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-  // This is a minimum example of using the class
-  include("../FeedTypes.php");
-  
-  //Creating an instance of RSS2FeedWriter class. 
-  $TestFeed = new RSS2FeedWriter();
-  
-  //Setting the channel elements
-  //Use wrapper functions for common channel elements
-  $TestFeed->setTitle('Testing & Checking the RSS writer class');
-  $TestFeed->setLink('http://www.ajaxray.com/projects/rss');
-  $TestFeed->setDescription('This is a test of creating a RSS 2.0 feed Universal Feed Writer');
-  
-  //Image title and link must match with the 'title' and 'link' channel elements for valid RSS 2.0
-  $TestFeed->setImage('Testing the RSS writer class','http://www.ajaxray.com/projects/rss','http://www.rightbrainsolution.com/_resources/img/logo.png');
-  
-  //Let's add some feed items: Create two empty FeedItem instances
-  $itemOne = $TestFeed->createNewItem();
-  $itemTwo = $TestFeed->createNewItem();
-  
-  //Add item details
-  $itemOne->setTitle('The title of the first entry.');
-  $itemOne->setLink('http://www.google.de');
-  $itemOne->setDate(time());
-  $itemOne->setDescription('And here\'s the description of the entry.');
-  $itemTwo->setTitle('Lorem ipsum');
-  $itemTwo->setLink('http://www.example.com');
-  $itemTwo->setDate(1234567890);
-  $itemTwo->setDescription('Lorem ipsum dolor sit amet, consectetur, adipisci velit');
-  
-  //Now add the feed item
-  $TestFeed->addItem($itemOne);
-  $TestFeed->addItem($itemTwo);
-  
-  //OK. Everything is done. Now genarate the feed.
-  $TestFeed->generateFeed();
-  
-?>
+//Creating an instance of RSS2 class.
+$TestFeed = new RSS2;
+
+//Setting the channel elements
+//Use wrapper functions for common channel elements
+$TestFeed->setTitle('Testing & Checking the RSS writer class');
+$TestFeed->setLink('http://www.ajaxray.com/projects/rss');
+$TestFeed->setDescription('This is a test of creating a RSS 2.0 feed Universal Feed Writer');
+
+//Image title and link must match with the 'title' and 'link' channel elements for valid RSS 2.0
+$TestFeed->setImage('Testing the RSS writer class','http://www.ajaxray.com/projects/rss','http://www.rightbrainsolution.com/_resources/img/logo.png');
+
+//Let's add some feed items: Create two empty Item instances
+$itemOne = $TestFeed->createNewItem();
+$itemTwo = $TestFeed->createNewItem();
+
+//Add item details
+$itemOne->setTitle('The title of the first entry.');
+$itemOne->setLink('http://www.google.de');
+$itemOne->setDate(time());
+$itemOne->setDescription('And here\'s the description of the entry.');
+
+$itemTwo->setTitle('Lorem ipsum');
+$itemTwo->setLink('http://www.example.com');
+$itemTwo->setDate(1234567890);
+$itemTwo->setDescription('Lorem ipsum dolor sit amet, consectetur, adipisci velit');
+
+//Now add the feed item
+$TestFeed->addItem($itemOne);
+$TestFeed->addItem($itemTwo);
+
+//OK. Everything is done. Now generate the feed.
+$TestFeed->generateFeed();

--- a/examples/example_rss1.php
+++ b/examples/example_rss1.php
@@ -1,4 +1,5 @@
 <?php
+use \FeedWriter\RSS1;
 
 /* 
  * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
@@ -19,48 +20,42 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-  
-  include("../FeedTypes.php");
-  
-  //Creating an instance of RSS1FeedWriter class. 
-  //The constant RSS1 is passed to mention the version
-  $TestFeed = new RSS1FeedWriter();
-  
-  //Setting the channel elements
-  //Use wrapper functions for common elements
-  //For other optional channel elements, use setChannelElement() function
-  $TestFeed->setTitle('Testing the RSS writer class');
-  $TestFeed->setLink('http://www.ajaxray.com/rss2/channel/about');
-  $TestFeed->setDescription('This is test of creating a RSS 1.0 feed by Universal Feed Writer');
-   
-  //It's important for RSS 1.0 
-  $TestFeed->setChannelAbout('http://www.ajaxray.com/rss2/channel/about');
-  
-  //Adding a feed. Genarally this protion will be in a loop and add all feeds.
-  
-  //Create an empty FeedItem
-  $newItem = $TestFeed->createNewItem();
-  
-  //Add elements to the feed item
-  //Use wrapper functions to add common feed elements
-  $newItem->setTitle('The first feed');
-  $newItem->setLink('http://www.yahoo.com');
-  //The parameter is a timestamp for setDate() function
-  $newItem->setDate(time());
-  $newItem->setDescription('This is test of adding CDATA encoded description by the php <b>Universal Feed Writer</b> class');
-  //Use core addElement() function for other supported optional elements
-  $newItem->addElement('dc:subject', 'Nothing but test');
-  
-  //Now add the feed item
-  $TestFeed->addItem($newItem);
-  
-  //Adding multiple elements from array
-  //Elements which have an attribute cannot be added by this way
-  $newItem = $TestFeed->createNewItem();
-  $newItem->addElementArray(array('title'=>'The 2nd feed', 'link'=>'http://www.google.com', 'description'=>'This is a test of the FeedWriter class'));
-  $TestFeed->addItem($newItem);
-  
-  //OK. Everything is done. Now genarate the feed.
-  $TestFeed->generateFeed();
-  
-?>
+//Creating an instance of RSS1 class.
+$TestFeed = new RSS1;
+
+//Setting the channel elements
+//Use wrapper functions for common elements
+//For other optional channel elements, use setChannelElement() function
+$TestFeed->setTitle('Testing the RSS writer class');
+$TestFeed->setLink('http://www.ajaxray.com/rss2/channel/about');
+$TestFeed->setDescription('This is test of creating a RSS 1.0 feed by Universal Feed Writer');
+
+//It's important for RSS 1.0 
+$TestFeed->setChannelAbout('http://www.ajaxray.com/rss2/channel/about');
+
+//Adding a feed. Generally this portion will be in a loop and add all feeds.
+
+//Create an empty FeedItem
+$newItem = $TestFeed->createNewItem();
+
+//Add elements to the feed item
+//Use wrapper functions to add common feed elements
+$newItem->setTitle('The first feed');
+$newItem->setLink('http://www.yahoo.com');
+//The parameter is a timestamp for setDate() function
+$newItem->setDate(time());
+$newItem->setDescription('This is test of adding CDATA encoded description by the php <b>Universal Feed Writer</b> class');
+//Use core addElement() function for other supported optional elements
+$newItem->addElement('dc:subject', 'Nothing but test');
+
+//Now add the feed item
+$TestFeed->addItem($newItem);
+
+//Adding multiple elements from array
+//Elements which have an attribute cannot be added by this way
+$newItem = $TestFeed->createNewItem();
+$newItem->addElementArray(array('title'=>'The 2nd feed', 'link'=>'http://www.google.com', 'description'=>'This is a test of the FeedWriter class'));
+$TestFeed->addItem($newItem);
+
+//OK. Everything is done. Now generate the feed.
+$TestFeed->printFeed();

--- a/examples/example_rss2.php
+++ b/examples/example_rss2.php
@@ -1,4 +1,5 @@
 <?php
+use \FeedWriter\RSS2;
 
 /* 
  * Copyright (C) 2008 Anis uddin Ahmad <anisniit@gmail.com>
@@ -19,54 +20,48 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-  
-  include("../FeedTypes.php");
-  
-  //Creating an instance of RSS2FeedWriter class. 
-  //The constant RSS2 is passed to mention the version
-  $TestFeed = new RSS2FeedWriter();
-  
-  //Setting the channel elements
-  //Use wrapper functions for common channel elements
-  $TestFeed->setTitle('Testing & Checking the RSS writer class');
-  $TestFeed->setLink('http://www.ajaxray.com/projects/rss');
-  $TestFeed->setDescription('This is a test of creating a RSS 2.0 feed with Universal Feed Writer');
-  
-  //Image title and link must match with the 'title' and 'link' channel elements for RSS 2.0
-  $TestFeed->setImage('Testing the RSS writer class','http://www.ajaxray.com/projects/rss','http://www.rightbrainsolution.com/_resources/img/logo.png');
-  
-  //Use core setChannelElement() function for other optional channels
-  $TestFeed->setChannelElement('language', 'en-us');
-  $TestFeed->setChannelElement('pubDate', date(DATE_RSS, time()));
-  
-  //Adding a feed. Genarally this portion will be in a loop and add all feeds.
-  
-  //Create an empty FeedItem
-  $newItem = $TestFeed->createNewItem();
-  
-  //Add elements to the feed item
-  //Use wrapper functions to add common feed elements
-  $newItem->setTitle('The first feed');
-  $newItem->setLink('http://www.yahoo.com');
-  //The parameter is a timestamp for setDate() function
-  $newItem->setDate(time());
-  $newItem->setDescription('This is a test of adding CDATA encoded description by the php <b>Universal Feed Writer</b> class');
-  $newItem->setEncloser('http://www.attrtest.com', '1283629', 'audio/mpeg');
-  //Use core addElement() function for other supported optional elements
-  $newItem->addElement('author', 'admin@ajaxray.com (Anis uddin Ahmad)');
-  //Attributes have to passed as array in 3rd parameter
-  $newItem->addElement('guid', 'http://www.ajaxray.com',array('isPermaLink'=>'true'));
-  
-  //Now add the feed item
-  $TestFeed->addItem($newItem);
-  
-  //Another method to add feeds from array()
-  //Elements which have attribute cannot be added by this way
-  $newItem = $TestFeed->createNewItem();
-  $newItem->addElementArray(array('title'=>'The 2nd feed', 'link'=>'http://www.google.com', 'description'=>'This is a test of the FeedWriter class'));
-  $TestFeed->addItem($newItem);
-  
-  //OK. Everything is done. Now genarate the feed.
-  $TestFeed->generateFeed();
-  
-?>
+//Creating an instance of RSS2 class.
+$TestFeed = new RSS2;
+
+//Setting the channel elements
+//Use wrapper functions for common channel elements
+$TestFeed->setTitle('Testing & Checking the RSS writer class');
+$TestFeed->setLink('http://www.ajaxray.com/projects/rss');
+$TestFeed->setDescription('This is a test of creating a RSS 2.0 feed with Universal Feed Writer');
+
+//Image title and link must match with the 'title' and 'link' channel elements for RSS 2.0
+$TestFeed->setImage('Testing the RSS writer class','http://www.ajaxray.com/projects/rss','http://www.rightbrainsolution.com/_resources/img/logo.png');
+
+//Use core setChannelElement() function for other optional channels
+$TestFeed->setChannelElement('language', 'en-us');
+$TestFeed->setChannelElement('pubDate', date(DATE_RSS, time()));
+
+//Adding a feed. Genarally this portion will be in a loop and add all feeds.
+
+//Create an empty FeedItem
+$newItem = $TestFeed->createNewItem();
+
+//Add elements to the feed item
+//Use wrapper functions to add common feed elements
+$newItem->setTitle('The first feed');
+$newItem->setLink('http://www.yahoo.com');
+//The parameter is a timestamp for setDate() function
+$newItem->setDate(time());
+$newItem->setDescription('This is a test of adding CDATA encoded description by the php <b>Universal Feed Writer</b> class');
+$newItem->setEncloser('http://www.attrtest.com', '1283629', 'audio/mpeg');
+//Use core addElement() function for other supported optional elements
+$newItem->addElement('author', 'admin@ajaxray.com (Anis uddin Ahmad)');
+//Attributes have to passed as array in 3rd parameter
+$newItem->addElement('guid', 'http://www.ajaxray.com',array('isPermaLink'=>'true'));
+
+//Now add the feed item
+$TestFeed->addItem($newItem);
+
+//Another method to add feeds from array()
+//Elements which have attribute cannot be added by this way
+$newItem = $TestFeed->createNewItem();
+$newItem->addElementArray(array('title'=>'The 2nd feed', 'link'=>'http://www.google.com', 'description'=>'This is a test of the FeedWriter class'));
+$TestFeed->addItem($newItem);
+
+//OK. Everything is done. Now generate the feed.
+echo $TestFeed->generateFeed();


### PR DESCRIPTION
A minimal set of changes to support PSR-0-style autoloading:
- rename base class to `\FeedWriter\Feed` and `FeedItem` to `\FeedWriter\Item`
- break types out into `\FeedWriter\ATOM`, `\FeedWriter\RSS1`, and
  `\FeedWriter\RSS2`
- use class constants for versions
- make `generateFeed()` return a string rather than doing any IO itself
- add `printFeed()` to do output, if needed
- updated example code

My rationale for the generateFeed()/printFeed() change is that our web framework expects me to pass around strings, not do direct IO. I imagine needing to grab the output and stash it in a variable or what-have-you is a common use case, and it felt silly to wrap this in an output buffer to accomplish that.

I went with FeedWriter for the base namespace, per @mibe's original suggestion, since it seemed nice and descriptive. If @ajaxray would strongly prefer that it be something like \axjaxray\FeedWriter, we could go that route easily enough.

Any comments appreciated.
