### PR TITLE
Add setContent() for Atom feed items

### DIFF
--- a/ATOM.php
+++ b/ATOM.php
@@ -31,4 +31,5 @@ class Atom extends Feed
 	{
 		parent::__construct(Feed::ATOM);
 	}
+
 }

--- a/Item.php
+++ b/Item.php
@@ -123,6 +123,19 @@ class Item
 		$tag = ($this->version == Feed::ATOM) ? 'summary' : 'description';
 		$this->addElement($tag, $description);
 	}
+
+	/**
+	 * Set the 'content' element of the feed item
+	 *
+	 * @access public
+	 * @param string Content for the item (i.e., the body of a blog post).
+	 * @return void
+	 */
+	function setContent($content)
+	{
+		$this->addElement('content', $content, array('type' => 'html'));
+	}
+
 	
 	/**
 	* @desc     Set the 'title' element of feed item
@@ -197,7 +210,7 @@ class Item
 	}
 	
 	/**
-	* Set the 'encloser' element of feed item
+	* Set the 'enclosure' element of feed item
 	* For RSS 2.0 only
 	* 
 	* @access   public
@@ -206,7 +219,7 @@ class Item
 	* @param    string  The type attribute of encloser tag
 	* @return   void
 	*/
-	public function setEncloser($url, $length, $type)
+	public function setEnclosure($url, $length, $type)
 	{
 		if ($this->version != Feed::RSS2)
 			return;

--- a/examples/example_atom.php
+++ b/examples/example_atom.php
@@ -4,7 +4,9 @@
 // This is done here only to make the examples work out of the box.
 include('../Item.php');
 include('../Feed.php');
-include('../Atom.php');
+include('../ATOM.php');
+
+date_default_timezone_set('UTC');
 
 use \FeedWriter\ATOM;
 
@@ -54,6 +56,7 @@ $newItem->setLink('http://www.yahoo.com');
 $newItem->setDate(time());
 //Internally changed to "summary" tag for ATOM feed
 $newItem->setDescription('This is a test of adding CDATA encoded description by the php <b>Universal Feed Writer</b> class');
+$newItem->setContent('<h1>hi.</h1> <p>This is the content for the entry.</p>');
 
 //Now add the feed item	
 $TestFeed->addItem($newItem);

--- a/examples/example_minimum.php
+++ b/examples/example_minimum.php
@@ -6,6 +6,8 @@ include('../Item.php');
 include('../Feed.php');
 include('../RSS2.php');
 
+date_default_timezone_set('UTC');
+
 use \FeedWriter\RSS2;
 
 /* 

--- a/examples/example_rss1.php
+++ b/examples/example_rss1.php
@@ -6,6 +6,8 @@ include('../Item.php');
 include('../Feed.php');
 include('../RSS1.php');
 
+date_default_timezone_set('UTC');
+
 use \FeedWriter\RSS1;
 
 /* 

--- a/examples/example_rss2.php
+++ b/examples/example_rss2.php
@@ -6,6 +6,8 @@ include('../Item.php');
 include('../Feed.php');
 include('../RSS2.php');
 
+date_default_timezone_set('UTC');
+
 use \FeedWriter\RSS2;
 
 /* 
@@ -60,7 +62,7 @@ $newItem->setLink('http://www.yahoo.com');
 //The parameter is a timestamp for setDate() function
 $newItem->setDate(time());
 $newItem->setDescription('This is a test of adding CDATA encoded description by the php <b>Universal Feed Writer</b> class');
-$newItem->setEncloser('http://www.attrtest.com', '1283629', 'audio/mpeg');
+$newItem->setEnclosure('http://www.attrtest.com', '1283629', 'audio/mpeg');
 //Use core addElement() function for other supported optional elements
 $newItem->addElement('author', 'admin@ajaxray.com (Anis uddin Ahmad)');
 //Attributes have to passed as array in 3rd parameter


### PR DESCRIPTION
In the process of rolling our stuff over to FeedWriter, I realized we needed to be able to include the full content of entries. So:
- Make it easy to get a `<content>` element on Atom entries
- Spell "enclosure" correctly - "setEncloser" -> "setEnclosure"
- Fix Atom test file on case-sensitive filesystems
- Tack a `date_default_timezone_set()` on tests, to avoid warnings

I contemplated a pretty major overhaul of the library while looking at this, but I think anything I'd do would amount to a full rewrite, and I don't think I'm quite ready to spend that much time reading RFCs and fighting with validators at the moment. :)
