### PR TITLE
Added optional setPagination method that gives the possibility to add pagination links to feed pages

### DIFF
--- a/Feed.php
+++ b/Feed.php
@@ -640,7 +640,10 @@ abstract class Feed
       $out = '';
       foreach($this->pagination as $rel=>$url)
       {
-        $out .= $this->makeNode('link', '', array('rel' => $rel, 'href' => $url));
+        if ($url && !empty($url))
+        {
+          $out .= $this->makeNode('link', '', array('rel' => $rel, 'href' => $url));
+        }
       }
       
       return $out;


### PR DESCRIPTION
As reported also in issue #18 it is not possible to add links with `rel` and `href` attributes using `setChannelElement` or `setLink` methods. This is why I've implemented this new `setPagination` method to easily add pagination links following these documentation  http://tools.ietf.org/html/rfc5005#section-3.

This methods accepts the following parameters:
- self URL: url to the current feed page, required
- next URL: url to the next page, optional
- previous URL: url to the previous page, optional
- first URL: url to the first page, optional
- last URL: url to the last page, optional
