### PR TITLE
Replace invalid xml utf-8 chars in tag contents.

### DIFF
--- a/Feed.php
+++ b/Feed.php
@@ -183,7 +183,7 @@ abstract class Feed
     */
     public function setChannelElement($elementName, $content, $attributes = null, $multiple = false)
     {
-        $entity['content'] = self::utf8_for_xml($content);
+        $entity['content'] = $content;
         $entity['attributes'] = $attributes;
 
         if ($multiple === TRUE)
@@ -699,6 +699,7 @@ abstract class Feed
 
         if (is_array($attributes) && count($attributes) > 0) {
             foreach ($attributes as $key => $value) {
+                $value = self::utf8_for_xml($value);
                 $value = htmlspecialchars($value);
                 $attrText .= " $key=\"$value\"";
             }
@@ -717,6 +718,7 @@ abstract class Feed
                 $nodeText .= $this->makeNode($key, $value);
             }
         } else {
+            $tagContent = self::utf8_for_xml($tagContent);
             $nodeText .= (in_array($tagName, $this->CDATAEncoding)) ? $this->sanitizeCDATA($tagContent) : htmlspecialchars($tagContent);
         }
 

--- a/Item.php
+++ b/Item.php
@@ -95,7 +95,7 @@ class Item
         }
 
         $this->elements[$key]['name']       = $elementName;
-        $this->elements[$key]['content']    = Feed::utf8_for_xml($content);
+        $this->elements[$key]['content']    = $content;
         $this->elements[$key]['attributes'] = $attributes;
 
         return $this;


### PR DESCRIPTION
I was getting issue to validate some feeds and finally found that not all utf-8 chars are valid for xml: http://www.phpwact.org/php/i18n/charsets#xml

So this commit insert the function found in the above link and use it when a string must be inserted into content tags.
