### PR TITLE
Get all names from feed items: optimisation

### DIFF
--- a/Feed.php
+++ b/Feed.php
@@ -624,8 +624,13 @@ abstract class Feed
         $tags = array_keys($this->channels);
 
         // ... and now all names from feed items
-        foreach ($this->items as $item)
-            $tags = array_merge($tags, array_keys($item->getElements()));
+        foreach ($this->items as $item) {
+            foreach (array_keys($item->getElements()) as $key) {
+                if (!in_array($key, $tags)) {
+                    $tags[] = $key;
+                }
+            }
+        }
 
         // Look for prefixes in those tag names
         foreach ($tags as $tag) {


### PR DESCRIPTION
array_merge spends several minutes to merge all namespaces on ~40k items which was quite unacceptable.
Replaced slow array_merge with array element assignment with uniqueness check which is enough in this case. 
Now it spends 2 seconds on ~40k items on my machine.