### PR TITLE
use correct fallback array access

### DIFF
--- a/Feed.php
+++ b/Feed.php
@@ -786,7 +786,7 @@ abstract class Feed
                 $out .= '<channel>' . PHP_EOL;
                 break;
             case Feed::RSS1:
-                $out .= (isset($this->data['ChannelAbout']))? "<channel rdf:about=\"{$this->data['ChannelAbout']}\">" : "<channel rdf:about=\"{$this->channels['link']}\">";
+                $out .= (isset($this->data['ChannelAbout']))? "<channel rdf:about=\"{$this->data['ChannelAbout']}\">" : "<channel rdf:about=\"{$this->channels['link']['content']}\">";
                 break;
         }
 


### PR DESCRIPTION
use correct array access, cause in https://github.com/mibe/FeedWriter/blob/master/Feed.php#L192 the channel value is always an array.