### PR TITLE
Docblock improvements + best practices

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+examples export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+vendor/

--- a/Feed.php
+++ b/Feed.php
@@ -41,7 +41,7 @@ abstract class Feed
     const RSS1 = 'RSS 1.0';
     const RSS2 = 'RSS 2.0';
     const ATOM = 'ATOM';
-    
+
     const VERSION = '1.1.0';
 
     /**
@@ -75,14 +75,14 @@ abstract class Feed
     * Contains the format of this feed.
     */
     private $version       = null;
-    
+
     /**
-    * Constructor
-    *
-    * If no version is given, a feed in RSS 2.0 format will be generated.
-    *
-    * @param    constant  the version constant (RSS1/RSS2/ATOM).
-    */
+     * Constructor
+     *
+     * If no version is given, a feed in RSS 2.0 format will be generated.
+     *
+     * @param string $version the version constant (RSS1/RSS2/ATOM).
+     */
     protected function __construct($version = Feed::RSS2)
     {
         $this->version = $version;
@@ -107,19 +107,19 @@ abstract class Feed
     }
 
     // Start # public functions ---------------------------------------------
-    
+
     /**
     * Set the URLs for feed pagination.
     *
     * See RFC 5005, chapter 3. At least one page URL must be specified.
     *
-    * @param   string  The URL to the next page of this feed. Optional.
-    * @param   string  The URL to the previous page of this feed. Optional.
-    * @param   string  The URL to the first page of this feed. Optional.
-    * @param   string  The URL to the last page of this feed. Optional.
+    * @param   string $nextURL The URL to the next page of this feed. Optional.
+    * @param   string $previousURL The URL to the previous page of this feed. Optional.
+    * @param   string $firstURL The URL to the first page of this feed. Optional.
+    * @param   string $lastURL The URL to the last page of this feed. Optional.
     * @link    http://tools.ietf.org/html/rfc5005#section-3
     * @return  self
-    * @throws  LogicException if none of the parameters are set.
+    * @throws  \LogicException if none of the parameters are set.
      */
     public function setPagination($nextURL = null, $previousURL = null, $firstURL = null, $lastURL = null)
     {
@@ -164,11 +164,11 @@ abstract class Feed
     * custom channel elements can be used properly to generate a valid feed.
     *
     * @access   public
-    * @param    string  namespace prefix
-    * @param    string  namespace name (URI)
+    * @param    string $prefix namespace prefix
+    * @param    string $uri namespace name (URI)
     * @return   self
     * @link     http://www.w3.org/TR/REC-xml-names/
-    * @throws   InvalidArgumentException if the prefix or uri is empty or NULL.
+    * @throws   \InvalidArgumentException if the prefix or uri is empty or NULL.
     */
     public function addNamespace($prefix, $uri)
     {
@@ -176,7 +176,7 @@ abstract class Feed
             throw new \InvalidArgumentException('The prefix may not be emtpy or NULL.');
         if (empty($uri))
             throw new \InvalidArgumentException('The uri may not be empty or NULL.');
-        
+
         $this->namespaces[$prefix] = $uri;
 
         return $this;
@@ -186,12 +186,12 @@ abstract class Feed
     * Add a channel element to the feed.
     *
     * @access   public
-    * @param    string  name of the channel tag
-    * @param    string  content of the channel tag
+    * @param    string $elementName name of the channel tag
+    * @param    string $content content of the channel tag
     * @param    array   array of element attributes with attribute name as array key
     * @param    bool    TRUE if this element can appear multiple times
     * @return   self
-    * @throws   InvalidArgumentException if the element name is not a string, empty or NULL.
+    * @throws   \InvalidArgumentException if the element name is not a string, empty or NULL.
     */
     public function setChannelElement($elementName, $content, array $attributes = null, $multiple = false)
     {
@@ -259,7 +259,7 @@ abstract class Feed
     * @access   public
     * @param    bool    FALSE if the specific feed media type should be sent.
     * @return   void
-    * @throws   InvalidArgumentException if the useGenericContentType parameter is not boolean.
+    * @throws   \InvalidArgumentException if the useGenericContentType parameter is not boolean.
     */
     public function printFeed($useGenericContentType = false)
     {
@@ -289,7 +289,7 @@ abstract class Feed
     {
         if ($this->version != Feed::ATOM && !array_key_exists('link', $this->channels))
             throw new InvalidOperationException('RSS1 & RSS2 feeds need a link element. Call the setLink method before this method.');
-        
+
         return $this->makeHeader()
             . $this->makeChannels()
             . $this->makeItems()
@@ -313,7 +313,7 @@ abstract class Feed
      * Add one or more tags to the list of CDATA encoded tags
      *
      * @access  public
-     * @param   array   An array of tag names that are merged into the list of tags which should be encoded as CDATA
+     * @param   array  $tags An array of tag names that are merged into the list of tags which should be encoded as CDATA
      * @return  self
      */
     public function addCDATAEncoding(array $tags)
@@ -333,12 +333,12 @@ abstract class Feed
     {
         return $this->CDATAEncoding;
     }
-    
+
     /**
      * Remove tags from the list of CDATA encoded tags
      *
      * @access  public
-     * @param   array   An array of tag names that should be removed.
+     * @param   array  $tags An array of tag names that should be removed.
      * @return  void
      */
     public function removeCDATAEncoding(array $tags)
@@ -351,9 +351,9 @@ abstract class Feed
     * Add a FeedItem to the main class
     *
     * @access   public
-    * @param    Item    instance of Item class
+    * @param    Item   $feedItem instance of Item class
     * @return   self
-    * @throws   InvalidArgumentException if the given item version mismatches.
+    * @throws   \InvalidArgumentException if the given item version mismatches.
     */
     public function addItem(Item $feedItem)
     {
@@ -374,9 +374,9 @@ abstract class Feed
     * Set the 'encoding' attribute in the XML prolog.
     *
     * @access   public
-    * @param    string  value of 'encoding' attribute
+    * @param    string $encoding value of 'encoding' attribute
     * @return   self
-    * @throws   InvalidArgumentException if the encoding is not a string, empty or NULL.
+    * @throws   \InvalidArgumentException if the encoding is not a string, empty or NULL.
     */
     public function setEncoding($encoding)
     {
@@ -384,7 +384,7 @@ abstract class Feed
             throw new \InvalidArgumentException('The encoding may not be empty or NULL.');
         if (!is_string($encoding))
             throw new \InvalidArgumentException('The encoding must be a string.');
-        
+
         $this->encoding = $encoding;
 
         return $this;
@@ -394,7 +394,7 @@ abstract class Feed
     * Set the 'title' channel element
     *
     * @access   public
-    * @param    string  value of 'title' channel tag
+    * @param    string $title value of 'title' channel tag
     * @return   self
     */
     public function setTitle($title)
@@ -414,7 +414,7 @@ abstract class Feed
     * @access   public
     * @param    DateTime|int|string  Date which should be used.
     * @return   self
-    * @throws   InvalidArgumentException if the given date is not an instance of DateTime, a UNIX timestamp or a date string.
+    * @throws   \InvalidArgumentException if the given date is not an instance of DateTime, a UNIX timestamp or a date string.
     * @throws   InvalidOperationException if this method is called on an RSS1 feed.
     */
     public function setDate($date)
@@ -434,7 +434,7 @@ abstract class Feed
             $timestamp = strtotime($date);
             if ($timestamp === FALSE)
                 throw new \InvalidArgumentException('The given date was not parseable.');
-            
+
             $date = date($format, $timestamp);
         }
         else
@@ -452,7 +452,7 @@ abstract class Feed
     * Set a phrase or sentence describing the feed.
     *
     * @access   public
-    * @param    string  Description of the feed.
+    * @param    string  $description Description of the feed.
     * @return   self
     */
     public function setDescription($description)
@@ -469,7 +469,7 @@ abstract class Feed
     * Set the 'link' channel element
     *
     * @access   public
-    * @param    string  value of 'link' channel tag
+    * @param    string $link value of 'link' channel tag
     * @return   self
     */
     public function setLink($link)
@@ -489,16 +489,16 @@ abstract class Feed
     * type and hreflang values.
     *
     * @access   public
-    * @param    string  URI of this link
-    * @param    string  relation type of the resource
-    * @param    string  MIME type of the target resource
-    * @param    string  language of the resource
-    * @param    string  human-readable information about the resource
-    * @param    int     length of the resource in bytes
+    * @param    string $href     URI of this link
+    * @param    string $rel      relation type of the resource
+    * @param    string $type     MIME type of the target resource
+    * @param    string $hreflang language of the resource
+    * @param    string $title    human-readable information about the resource
+    * @param    int    $length   length of the resource in bytes
     * @link     https://www.iana.org/assignments/link-relations/link-relations.xml
     * @link     https://tools.ietf.org/html/rfc4287#section-4.2.7
     * @return   self
-    * @throws   InvalidArgumentException on multiple occasions.
+    * @throws   \InvalidArgumentException on multiple occasions.
     * @throws   InvalidOperationException if the same link with the same attributes was already added to the feed.
     */
     public function setAtomLink($href, $rel = null, $type = null, $hreflang = null, $title = null, $length = null)
@@ -565,7 +565,7 @@ abstract class Feed
     *
     * @link     http://www.rssboard.org/rss-profile#namespace-elements-atom-link
     * @access   public
-    * @param    string  URL to this feed
+    * @param    string $url URL to this feed
     * @return   self
     */
     public function setSelfLink($url)
@@ -577,12 +577,12 @@ abstract class Feed
     * Set the 'image' channel element
     *
     * @access   public
-    * @param    string  URL of the image
-    * @param    string  Title of the image. RSS only.
-    * @param    string  Link target URL of the image. RSS only.
+    * @param    string $url URL of the image
+    * @param    string $title Title of the image. RSS only.
+    * @param    string $link Link target URL of the image. RSS only.
     * @return   self
-    * @throws   InvalidArgumentException if the url is invalid.
-    * @throws   InvalidArgumentException if the title and link parameter are not a string or empty.
+    * @throws   \InvalidArgumentException if the url is invalid.
+    * @throws   \InvalidArgumentException if the title and link parameter are not a string or empty.
     */
     public function setImage($url, $title = null, $link = null)
     {
@@ -605,7 +605,7 @@ abstract class Feed
             $name = 'logo';
             $data = $url;
         }
-        
+
         // Special handling for RSS1 again (since RSS1 is a bit strange...)
         if ($this->version == Feed::RSS1)
         {
@@ -620,10 +620,10 @@ abstract class Feed
     * Set the channel 'rdf:about' attribute, which is used in RSS1 feeds only.
     *
     * @access   public
-    * @param    string  value of 'rdf:about' attribute of the channel element
+    * @param    string $url value of 'rdf:about' attribute of the channel element
     * @return   self
     * @throws   InvalidOperationException if this method is called and the feed is not of type RSS1.
-    * @throws   InvalidArgumentException if the given URL is invalid.
+    * @throws   \InvalidArgumentException if the given URL is invalid.
     */
     public function setChannelAbout($url)
     {
@@ -647,9 +647,9 @@ abstract class Feed
     *
     * @author   Anis uddin Ahmad <admin@ajaxray.com>
     * @access   public
-    * @param    string  optional key on which the UUID is generated
-    * @param    string  an optional prefix
-    * @return   string  the formated UUID
+    * @param    string $key    optional key on which the UUID is generated
+    * @param    string $prefix an optional prefix
+    * @return   string         the formatted UUID
     */
     public static function uuid($key = null, $prefix = '')
     {
@@ -672,14 +672,14 @@ abstract class Feed
     * @link https://github.com/mibe/FeedWriter/issues/30
     *
     * @access   public
-    * @param    string  string which should be filtered
-    * @param    string  replace invalid characters with this string
-    * @return   string  the filtered string
+    * @param    string $string      string which should be filtered
+    * @param    string $replacement replace invalid characters with this string
+    * @return   string              the filtered string
     */
     public static function filterInvalidXMLChars($string, $replacement = '_') // default to '\x{FFFD}' ???
     {
         $result = preg_replace('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/u', $replacement, $string);
-        
+
         // Did the PCRE replace failed because of bad UTF-8 data?
         // If yes, try a non-multibyte regex and without the UTF-8 mode enabled.
         if ($result == NULL && preg_last_error() == PREG_BAD_UTF8_ERROR)
@@ -688,7 +688,7 @@ abstract class Feed
         // In case the regex replacing failed completely, return the whole unfiltered string.
         if ($result == NULL)
             $result = $string;
-        
+
         return $result;
     }
     // End # public functions ----------------------------------------------
@@ -738,7 +738,7 @@ abstract class Feed
     *
     * @access   private
     * @return   string  The XML header of the feed.
-    * @throws   InvalidOperationException if an unkown XML namespace prefix is encountered.
+    * @throws   InvalidOperationException if an unknown XML namespace prefix is encountered.
     */
     private function makeHeader()
     {
@@ -783,7 +783,7 @@ abstract class Feed
 
         return $out;
     }
-    
+
     /**
     * Closes the open tags at the end of file
     *
@@ -805,12 +805,12 @@ abstract class Feed
     * Creates a single node in XML format
     *
     * @access   private
-    * @param    string  name of the tag
-    * @param    mixed   tag value as string or array of nested tags in 'tagName' => 'tagValue' format
-    * @param    array   Attributes (if any) in 'attrName' => 'attrValue' format
-    * @param    string  True if the end tag should be omitted. Defaults to false.
+    * @param    string $tagName    name of the tag
+    * @param    mixed  $tagContent tag value as string or array of nested tags in 'tagName' => 'tagValue' format
+    * @param    array  $attributes Attributes (if any) in 'attrName' => 'attrValue' format
+    * @param    bool $omitEndTag True if the end tag should be omitted. Defaults to false.
     * @return   string  formatted xml tag
-    * @throws   InvalidArgumentException if the tagContent is not an array and not a string.
+    * @throws   \InvalidArgumentException if the tagContent is not an array and not a string.
     */
     private function makeNode($tagName, $tagContent, array $attributes = null, $omitEndTag = false)
     {
@@ -884,7 +884,7 @@ abstract class Feed
             if ($this->version == Feed::ATOM && strncmp($key, 'atom', 4) == 0) {
                 $key = substr($key, 5);
             }
-            
+
             // The channel element can occur multiple times, when the key 'content' is not in the array.
             if (!array_key_exists('content', $value)) {
                 // If this is the case, iterate through the array with the multiple elements.
@@ -956,8 +956,8 @@ abstract class Feed
     * Make the starting tag of channels
     *
     * @access   private
-    * @param    string  The value of about attribute which is used for RSS 1.0 only.
-    * @return   string  The starting XML tag of an feed item.
+    * @param    string $about The value of about attribute which is used for RSS 1.0 only.
+    * @return   string        The starting XML tag of an feed item.
     * @throws   InvalidOperationException if this object misses the data for the about attribute.
     */
     private function startItem($about = false)
@@ -1001,7 +1001,7 @@ abstract class Feed
     * XML, so the brackets are converted to a HTML entity.
     *
     * @access   private
-    * @param    string  Data to be sanitized
+    * @param    string $text Data to be sanitized
     * @return   string  Sanitized data
     */
     private function sanitizeCDATA($text)

--- a/Item.php
+++ b/Item.php
@@ -52,7 +52,7 @@ class Item
     /**
     * Constructor
     *
-    * @param    constant  (RSS1/RSS2/ATOM) RSS2 is default.
+    * @param string $version constant (RSS1/RSS2/ATOM) RSS2 is default.
     */
     public function __construct($version = Feed::RSS2)
     {
@@ -74,13 +74,13 @@ class Item
     * Add an element to elements array
     *
     * @access   public
-    * @param    string  The tag name of an element
-    * @param    string  The content of tag
-    * @param    array   Attributes (if any) in 'attrName' => 'attrValue' format
-    * @param    boolean Specifies if an already existing element is overwritten.
-    * @param    boolean Specifies if multiple elements of the same name are allowed.
+    * @param    string $elementName    The tag name of an element
+    * @param    string $content        The content of tag
+    * @param    array  $attributes     Attributes (if any) in 'attrName' => 'attrValue' format
+    * @param    boolean $overwrite     Specifies if an already existing element is overwritten.
+    * @param    boolean $allowMultiple Specifies if multiple elements of the same name are allowed.
     * @return   self
-    * @throws   InvalidArgumentException if the element name is not a string, empty or NULL.
+    * @throws   \InvalidArgumentException if the element name is not a string, empty or NULL.
     */
     public function addElement($elementName, $content, array $attributes = null, $overwrite = FALSE, $allowMultiple = FALSE)
     {
@@ -95,7 +95,7 @@ class Item
         // & if multiple elements are not allowed.
         if (isset($this->elements[$elementName]) && !$overwrite) {
             if (!$allowMultiple)
-                return;
+                return $this;
 
             $key .= '-' . $this->cpt();
         }
@@ -175,7 +175,7 @@ class Item
     * Set the 'description' element of feed item
     *
     * @access   public
-    * @param    string  The content of the 'description' or 'summary' element
+    * @param    string $description The content of the 'description' or 'summary' element
     * @return   self
     */
     public function setDescription($description)
@@ -190,7 +190,7 @@ class Item
     * For ATOM feeds only
     *
     * @access   public
-    * @param    string  Content for the item (i.e., the body of a blog post).
+    * @param    string $content Content for the item (i.e., the body of a blog post).
     * @return   self
     * @throws   InvalidOperationException if this method is called on non-ATOM feeds.
     */
@@ -206,7 +206,7 @@ class Item
     * Set the 'title' element of feed item
     *
     * @access   public
-    * @param    string  The content of 'title' element
+    * @param    string $title The content of 'title' element
     * @return   self
     */
     public function setTitle($title)
@@ -222,9 +222,9 @@ class Item
     * which is parseable by PHP's 'strtotime' function.
     *
     * @access   public
-    * @param    DateTime|int|string  Date which should be used.
+    * @param    DateTime|int|string $date Date which should be used.
     * @return   self
-    * @throws   InvalidArgumentException if the given date was not parseable.
+    * @throws   \InvalidArgumentException if the given date was not parseable.
     */
     public function setDate($date)
     {
@@ -258,8 +258,8 @@ class Item
     * Set the 'link' element of feed item
     *
     * @access   public
-    * @param    string  The content of 'link' element
-    * @return   void
+    * @param    string $link The content of 'link' element
+    * @return   self
     */
     public function setLink($link)
     {
@@ -283,13 +283,13 @@ class Item
     * since some RSS aggregators don't support it.
     *
     * @access   public
-    * @param    string  The URL of the media.
-    * @param    integer The length of the media.
-    * @param    string  The MIME type attribute of the media.
-    * @param    boolean Specifies if multiple enclosures are allowed
+    * @param    string $url       The URL of the media.
+    * @param    integer $length   The length of the media.
+    * @param    string  $type     The MIME type attribute of the media.
+    * @param    boolean $multiple Specifies if multiple enclosures are allowed
     * @return   self
     * @link     https://tools.ietf.org/html/rfc4288
-    * @throws   InvalidArgumentException if the length or type parameter is invalid.
+    * @throws   \InvalidArgumentException if the length or type parameter is invalid.
     * @throws   InvalidOperationException if this method is called on RSS1 feeds.
     */
     public function addEnclosure($url, $length, $type, $multiple = TRUE)
@@ -325,22 +325,22 @@ class Item
     * Not supported in RSS 1.0 feeds.
     *
     * @access   public
-    * @param    string  The author of this item
-    * @param    string  Optional email address of the author
-    * @param    string  Optional URI related to the author
+    * @param    string $author The author of this item
+    * @param    string|null $email Optional email address of the author
+    * @param    string|null $uri Optional URI related to the author
     * @return   self
-    * @throws   InvalidArgumentException if the provided email address is syntactically incorrect.
+    * @throws   \InvalidArgumentException if the provided email address is syntactically incorrect.
     * @throws   InvalidOperationException if this method is called on RSS1 feeds.
     */
     public function setAuthor($author, $email = null, $uri = null)
     {
         if ($this->version == Feed::RSS1)
             throw new InvalidOperationException('The author element is not supported in RSS1 feeds.');
-        
+
         // Regex from RFC 4287 page 41
         if ($email != null && preg_match('/.+@.+/', $email) != 1)
             throw new \InvalidArgumentException('The email address is syntactically incorrect.');
-        
+
         if ($this->version == Feed::RSS2)
         {
             if ($email != null)
@@ -370,10 +370,10 @@ class Item
     * On ATOM feeds, the identifier must begin with an valid URI scheme.
     *
     * @access   public
-    * @param    string  The unique identifier of this item
-    * @param    boolean The value of the 'isPermaLink' attribute in RSS 2 feeds.
+    * @param    string $id         The unique identifier of this item
+    * @param    boolean $permaLink The value of the 'isPermaLink' attribute in RSS 2 feeds.
     * @return   self
-    * @throws   InvalidArgumentException if the permaLink parameter is not boolean.
+    * @throws   \InvalidArgumentException if the permaLink parameter is not boolean.
     * @throws   InvalidOperationException if this method is called on RSS1 feeds.
     */
     public function setId($id, $permaLink = false)
@@ -392,17 +392,17 @@ class Item
             $validSchemes = array('aaa', 'aaas', 'about', 'acap', 'acct', 'cap', 'cid', 'coap', 'coaps', 'crid', 'data', 'dav', 'dict', 'dns', 'example', 'fax', 'file', 'filesystem', 'ftp', 'geo', 'go', 'gopher', 'h323', 'http', 'https', 'iax', 'icap', 'im', 'imap', 'info', 'ipp', 'ipps', 'iris', 'iris.beep', 'iris.lwz', 'iris.xpc', 'iris.xpcs', 'jabber', 'ldap', 'mailserver', 'mailto', 'mid', 'modem', 'msrp', 'msrps', 'mtqp', 'mupdate', 'news', 'nfs', 'ni', 'nih', 'nntp', 'opaquelocktoken', 'pack', 'pkcs11', 'pop', 'pres', 'prospero', 'reload', 'rtsp', 'rtsps', 'rtspu', 'service', 'session', 'shttp', 'sieve', 'sip', 'sips', 'sms', 'snews', 'snmp', 'soap.beep', 'soap.beeps', 'stun', 'stuns', 'tag', 'tel', 'telnet', 'tftp', 'thismessage', 'tip', 'tn3270', 'turn', 'turns', 'tv', 'urn', 'vemmi', 'videotex', 'vnc', 'wais', 'ws', 'wss', 'xcon', 'xcon-userid', 'xmlrpc.beep', 'xmlrpc.beeps', 'xmpp', 'z39.50', 'z39.50r', 'z39.50s');
             $found = FALSE;
             $checkId = strtolower($id);
-            
+
             foreach($validSchemes as $scheme)
                 if (strrpos($checkId, $scheme . ':', -strlen($checkId)) !== FALSE)
                 {
                     $found = TRUE;
                     break;
                 }
-            
+
             if (!$found)
                 throw new \InvalidArgumentException("The ID must begin with an IANA-registered URI scheme.");
-            
+
             $this->addElement('id', $id, NULL, TRUE);
         } else
             throw new InvalidOperationException('A unique ID is not supported in RSS1 feeds.');

--- a/composer.json
+++ b/composer.json
@@ -57,14 +57,9 @@
     ],
     "minimum-stability": "dev",
     "autoload": {
-        "classmap": [
-            "ATOM.php",
-            "Feed.php",
-            "Item.php",
-            "RSS1.php",
-            "RSS2.php",
-            "InvalidOperationException.php"
-        ]
+        "psr-4": {
+            "FeedWriter\\": ""
+        }
     },
     "require" : {
         "php": ">=5.3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "aed42911969b0d236cf9743848d8582e",
+    "content-hash": "d8fc0ae3e220f5834869ff8b73aca888",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "aed42911969b0d236cf9743848d8582e",
+    "hash": "91f256f9c16112f0cfaf195351eb9ce7",
     "content-hash": "d8fc0ae3e220f5834869ff8b73aca888",
     "packages": [],
     "packages-dev": [],


### PR DESCRIPTION
This pull request improves the docblocks of the following classes
- FeedWriter\Feed
- FeedWriter\Item
This should give IDEs (like PHPStorm) better insights into the code and therefore much better type hinting.

Furthermore this PR adds or changes the following files:
- **.gitginore:** By default it ignores the .idea folder of PHPStorm and Composer's vendor folder
- **.gitattributes:** Added export-ignores for the examples folder, the .gitignore and .gitattributes files. This helps Composer to stay a little bit more clean, when fetching packages with the --prefer-dist option (https://blog.madewithlove.be/post/gitattributes/)
- **composer.json:** Changed from the classmap autoloader to the PSR-4 autoloader to make the local development a little bit easier
- **composer.lock:** Although the FeedWriter library uses Composer only for its autoloader, it is considered best practice to add the composer.lock file to the repository to bring the dependencies to a known state.