### PR TITLE
Cast $string to string if not string(ex:null) in filterInvalidXMLChars().

### DIFF
--- a/Feed.php
+++ b/Feed.php
@@ -678,6 +678,11 @@ abstract class Feed
     */
     public static function filterInvalidXMLChars($string, $replacement = '_') // default to '\x{FFFD}' ???
     {
+        // Convert $string to string if not string (ex:NULL).
+        // Avoid `preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated` error from PHP>=8.1.
+        if (!is_string($string))
+            $string = (string)$string;
+
         $result = preg_replace('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/u', $replacement, $string);
 
         // Did the PCRE replace failed because of bad UTF-8 data?


### PR DESCRIPTION
Hi.

I got a ignore-able tiny error with PHP>=8.1

- PHP>=8.1 trigger deprecation error in some old code.
- `Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /work/Feed.php on line 687`

###  ex code
```
// Add some line to sample code.

$nullable_value = null;
$TestFeed->setChannelElement('description', $nullable_value);

// ... SNIP ... 

$TestFeed->generateFeed(); // error.
```

### error output.
```
Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /work/Feed.php on line 687
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /work/Feed.php on line 1015
Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /work/Feed.php on line 687
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /work/Feed.php on line 1015
Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /work/Feed.php on line 687
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /work/Feed.php on line 1015
Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /work/Feed.php on line 687
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /work/Feed.php on line 1015
```


Of course, `$TestFeed->setChannelElement('something', NULL)` is absolutly wrong. but many php are still using NULL as blank strings.
It save some codes if cast NULL to string here.

thanks.