### PR TITLE
Declare missing encoding property

### DIFF
--- a/Feed.php
+++ b/Feed.php
@@ -78,6 +78,13 @@ abstract class Feed
     private $version       = null;
 
     /**
+    * Contains the encoding of this feed.
+    *
+    * @var string
+    */
+    private $encoding      = 'utf-8';
+
+    /**
      * Constructor
      *
      * If no version is given, a feed in RSS 2.0 format will be generated.
@@ -87,9 +94,6 @@ abstract class Feed
     protected function __construct($version = Feed::RSS2)
     {
         $this->version = $version;
-
-        // Setting default encoding
-        $this->encoding = 'utf-8';
 
         // Setting default value for essential channel element
         $this->setTitle($version . ' Feed');


### PR DESCRIPTION
Since PHP 8.2 dynamic properties are deprecated:

https://php.watch/versions/8.2/dynamic-properties-deprecated

As a result, the library would complain:

> Deprecated: Creation of dynamic property FeedWriter\ATOM::$encoding is deprecated in Feed.php on line 97

Let’s declare the property to fix the warning.

Making it public for backwards compatibility, since that is the implicit visibility of dynamic properties.
Also keep the initialization in the constructor to keep the behaviour the same.
