### PR TITLE
examples: Require correct file paths

### DIFF
--- a/Feed.php
+++ b/Feed.php
@@ -78,6 +78,13 @@ abstract class Feed
     private $version       = null;
 
     /**
+    * Contains the encoding of this feed.
+    *
+    * @var string
+    */
+    private $encoding      = 'utf-8';
+
+    /**
      * Constructor
      *
      * If no version is given, a feed in RSS 2.0 format will be generated.
@@ -87,9 +94,6 @@ abstract class Feed
     protected function __construct($version = Feed::RSS2)
     {
         $this->version = $version;
-
-        // Setting default encoding
-        $this->encoding = 'utf-8';
 
         // Setting default value for essential channel element
         $this->setTitle($version . ' Feed');

--- a/examples/example_atom.php
+++ b/examples/example_atom.php
@@ -2,10 +2,10 @@
 
 // You should use an autoloader instead of including the files directly.
 // This is done here only to make the examples work out of the box.
-include '../Item.php';
-include '../Feed.php';
-include '../ATOM.php';
-include '../InvalidOperationException.php';
+require_once __DIR__ . '/../Item.php';
+require_once __DIR__ . '/../Feed.php';
+require_once __DIR__ . '/../ATOM.php';
+require_once __DIR__ . '/../InvalidOperationException.php';
 
 date_default_timezone_set('UTC');
 

--- a/examples/example_minimum.php
+++ b/examples/example_minimum.php
@@ -2,10 +2,10 @@
 
 // You should use an autoloader instead of including the files directly.
 // This is done here only to make the examples work out of the box.
-include '../Item.php';
-include '../Feed.php';
-include '../RSS2.php';
-include '../InvalidOperationException.php';
+require_once __DIR__ . '/../Item.php';
+require_once __DIR__ . '/../Feed.php';
+require_once __DIR__ . '/../RSS2.php';
+require_once __DIR__ . '/../InvalidOperationException.php';
 
 date_default_timezone_set('UTC');
 

--- a/examples/example_rss1.php
+++ b/examples/example_rss1.php
@@ -2,10 +2,10 @@
 
 // You should use an autoloader instead of including the files directly.
 // This is done here only to make the examples work out of the box.
-include '../Item.php';
-include '../Feed.php';
-include '../RSS1.php';
-include '../InvalidOperationException.php';
+require_once __DIR__ . '/../Item.php';
+require_once __DIR__ . '/../Feed.php';
+require_once __DIR__ . '/../RSS1.php';
+require_once __DIR__ . '/../InvalidOperationException.php';
 
 date_default_timezone_set('UTC');
 

--- a/examples/example_rss2.php
+++ b/examples/example_rss2.php
@@ -2,10 +2,10 @@
 
 // You should use an autoloader instead of including the files directly.
 // This is done here only to make the examples work out of the box.
-include '../Item.php';
-include '../Feed.php';
-include '../RSS2.php';
-include '../InvalidOperationException.php';
+require_once __DIR__ . '/../Item.php';
+require_once __DIR__ . '/../Feed.php';
+require_once __DIR__ . '/../RSS2.php';
+require_once __DIR__ . '/../InvalidOperationException.php';
 
 date_default_timezone_set('UTC');
 


### PR DESCRIPTION
When running the examples from the repository root like `php examples/example_atom.php`, the scripts will complain and eventually fail:

    Warning: include(../Item.php): Failed to open stream: No such file or directory
    Fatal error: Uncaught Error: Class "FeedWriter\ATOM" not found

Let’s replace the `include`s with `require_once`s to fail eagerly on missing library and use absolute path through the `__DIR__` constant introduced in PHP 5.3 instead of relying on lookup paths.
